### PR TITLE
Logo personalizado, fondo gris, ico Mail nav superior, mejoras graficas

### DIFF
--- a/FRONTEND/FRONTEND/Views/Home/Index.cshtml
+++ b/FRONTEND/FRONTEND/Views/Home/Index.cshtml
@@ -5,10 +5,10 @@
 
     <nav id="navSecundario" class="navbar navbar-expand-lg navbar-light bg-light d-flex justify-content-around">
         <i class="fa-bars fa"></i><a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">Trabajadores</a>
-        <form></form>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
-            <button class="btn btn-outline-primary btn-sm" type="submit" style="margin-right: 5px;">Grupo Castilla (No tocar)</button>
-            <button class="btn btn-outline-primary btn-sm" type="submit">@DateTime.Now</button>
+
+        <div class="collapse navbar-collapse justify-content-end" id="navbarSupportedContent">
+            <button class="btn btn-outline-primary btn-sm disabled" style="margin-right: 5px;">Grupo Castilla</button>
+            <button class="btn btn-outline-primary btn-sm disabled">@DateTime.Now</button>
         </div>
     </nav>
     <div class="container-fluid">

--- a/FRONTEND/FRONTEND/Views/Paginas/FichaTrabajador.cshtml
+++ b/FRONTEND/FRONTEND/Views/Paginas/FichaTrabajador.cshtml
@@ -18,6 +18,7 @@
         Funciones
     </button>
     <div class="panel">
+        <hr />
         <p class="advertencia"><i class="fas fa-exclamation-triangle" style="margin-right:1em;"></i>Para guardar los cambios tan solo haga click fuera del texto</p>
         <hr>
         <p id="Funciones" class="texto" contenteditable="true">Aqui se muestran las funciones que desemplea el trabajador en la empresa.</p>
@@ -28,6 +29,7 @@
         Misiones
     </button>
     <div class="panel">
+        <hr />
         <p class="advertencia"><i class="fas fa-exclamation-triangle" style="margin-right:1em;"></i>Para guardar los cambios tan solo haga click fuera del texto</p>
         <hr>
         <p id="Misiones" class="texto" contenteditable="true">Aqui se muestran las misiones que tiene el trabajador en la empresa.</p>
@@ -38,6 +40,7 @@
         Titulaciones
     </button>
     <div class="panel">
+        <hr />
         <p class="advertencia"><i class="fas fa-exclamation-triangle" style="margin-right:1em;"></i>Para guardar los cambios tan solo haga click fuera del texto</p>
         <hr>
         <p id="Titulaciones" class="texto" contenteditable="true">Aqui se muestran las titutlaciones de las que dispone el trabajador.</p>
@@ -48,6 +51,7 @@
         Formación específica
     </button>
     <div class="panel">
+        <hr />
         <p class="advertencia"><i class="fas fa-exclamation-triangle" style="margin-right:1em;"></i>Para guardar los cambios tan solo haga click fuera del texto</p>
         <hr>
         <p id="Formacion" class="texto" contenteditable="true">Aqui se muestra la titulación específica de la que dispone el trabajador además de sus titulaciones.</p>
@@ -58,6 +62,7 @@
         Idiomas
     </button>
     <div class="panel">
+        <hr />
         <p class="advertencia"><i class="fas fa-exclamation-triangle" style="margin-right:1em;"></i>Para guardar los cambios tan solo haga click fuera del texto</p>
         <hr>
         <p id="Idiomas" class="texto" contenteditable="true">Aqui se muestran los idiomas que sabe el trabajador.</p>

--- a/FRONTEND/FRONTEND/Views/Paginas/MensajesTrabajador.cshtml
+++ b/FRONTEND/FRONTEND/Views/Paginas/MensajesTrabajador.cshtml
@@ -4,7 +4,7 @@
 
 
 
-<content class="main-content">
+<content id="MailPage" class="main-content">
 
     <aside class="main-sidebar">
         <div class="content">
@@ -52,7 +52,7 @@
                         <span class="k-link k-menu-link">Responder</span>
                     </li>
                     <li class="k-item k-menu-item" id="read" operation="read" role="menuitem">
-                        <span class="k-link k-menu-link">Marcar como leído</span>
+                        <span class="k-link k-menu-link mailOptions">Marcar como leído</span>
                     </li>
                     <li class="k-item k-menu-item" id="Deleted" operation="moveDelete" role="menuitem">
                         <span class="k-link k-menu-link">Borrar</span>
@@ -70,7 +70,7 @@
 
                     <div class="contact-view k-widget" role="option" aria-selected="false">
                         <div class="header">
-                            <span class="hidden-email" style="display:none">Zbyszek.Piestrzeniewicz@telerik.com</span>
+                            <span class="hidden-email correo" style="display:none">Zbyszek.Piestrzeniewicz@telerik.com</span>
                             <span class="image-wrapper">
                                 <i class="fas fa-portrait icoUser"></i>
                             </span>
@@ -88,7 +88,7 @@
 
                     <div class="contact-view k-widget" role="option" aria-selected="false">
                         <div class="header">
-                            <span class="hidden-email" style="display:none">Zbyszek.Piestrzeniewicz@telerik.com</span>
+                            <span class="hidden-email correo" style="display:none">Zbyszek.Piestrzeniewicz@telerik.com</span>
                             <span class="image-wrapper">
                                 <i class="fas fa-portrait icoUser"></i>
                             </span>
@@ -148,7 +148,7 @@
                             <span class="name">Ana Rodriguez</span>
                             <div class="buttons">
                                 <div class="option manoCursor">
-                                    <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="envelope-open-text" class="svg-inline--fa fa-envelope-open-text fa-w-16" role="img" viewBox="0 0 512 512"><path fill="currentColor" d="M176 216h160c8.84 0 16-7.16 16-16v-16c0-8.84-7.16-16-16-16H176c-8.84 0-16 7.16-16 16v16c0 8.84 7.16 16 16 16zm-16 80c0 8.84 7.16 16 16 16h160c8.84 0 16-7.16 16-16v-16c0-8.84-7.16-16-16-16H176c-8.84 0-16 7.16-16 16v16zm96 121.13c-16.42 0-32.84-5.06-46.86-15.19L0 250.86V464c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V250.86L302.86 401.94c-14.02 10.12-30.44 15.19-46.86 15.19zm237.61-254.18c-8.85-6.94-17.24-13.47-29.61-22.81V96c0-26.51-21.49-48-48-48h-77.55c-3.04-2.2-5.87-4.26-9.04-6.56C312.6 29.17 279.2-.35 256 0c-23.2-.35-56.59 29.17-73.41 41.44-3.17 2.3-6 4.36-9.04 6.56H96c-26.51 0-48 21.49-48 48v44.14c-12.37 9.33-20.76 15.87-29.61 22.81A47.995 47.995 0 0 0 0 200.72v10.65l96 69.35V96h320v184.72l96-69.35v-10.65c0-14.74-6.78-28.67-18.39-37.77z" /></svg>
+                                      <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="envelope-open-text" class="svg-inline--fa fa-envelope-open-text fa-w-16" role="img" viewBox="0 0 512 512"><path fill="currentColor" d="M176 216h160c8.84 0 16-7.16 16-16v-16c0-8.84-7.16-16-16-16H176c-8.84 0-16 7.16-16 16v16c0 8.84 7.16 16 16 16zm-16 80c0 8.84 7.16 16 16 16h160c8.84 0 16-7.16 16-16v-16c0-8.84-7.16-16-16-16H176c-8.84 0-16 7.16-16 16v16zm96 121.13c-16.42 0-32.84-5.06-46.86-15.19L0 250.86V464c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V250.86L302.86 401.94c-14.02 10.12-30.44 15.19-46.86 15.19zm237.61-254.18c-8.85-6.94-17.24-13.47-29.61-22.81V96c0-26.51-21.49-48-48-48h-77.55c-3.04-2.2-5.87-4.26-9.04-6.56C312.6 29.17 279.2-.35 256 0c-23.2-.35-56.59 29.17-73.41 41.44-3.17 2.3-6 4.36-9.04 6.56H96c-26.51 0-48 21.49-48 48v44.14c-12.37 9.33-20.76 15.87-29.61 22.81A47.995 47.995 0 0 0 0 200.72v10.65l96 69.35V96h320v184.72l96-69.35v-10.65c0-14.74-6.78-28.67-18.39-37.77z" /></svg>
                                 </div>
                                 <div class="option manoCursor">
                                     <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="trash-alt" class="svg-inline--fa fa-trash-alt fa-w-14" role="img" viewBox="0 0 448 512"><path fill="currentColor" d="M32 464a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128H32zm272-256a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zm-96 0a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zm-96 0a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zM432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z" /></svg>
@@ -158,7 +158,7 @@
                     </div>
 
 
-                    <div class="contact-view k-widget" uid="l8626bd4-eec7-4da3-86d8-677fb38e8278" data-uid="l8626bd4-eec7-4da3-86d8-677fb38e8278" role="option" aria-selected="false">
+                    <div class="contact-view k-widget" role="option" aria-selected="false">
                         <div class="header">
                             <span class="hidden-email" style="display:none">Zbyszek.Piestrzeniewicz@telerik.com</span>
                             <span class="image-wrapper">
@@ -194,7 +194,7 @@
                         </div>
                     </div>
 
-                    <div class="contact-view k-widget" uid="l8626bd4-eec7-4da3-86d8-677fb38e8278" data-uid="l8626bd4-eec7-4da3-86d8-677fb38e8278" role="option" aria-selected="false">
+                    <div class="contact-view k-widget" role="option" aria-selected="false">
                         <div class="header">
                             <span class="hidden-email" style="display:none">Zbyszek.Piestrzeniewicz@telerik.com</span>
                             <span class="image-wrapper">
@@ -228,7 +228,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="contact-view k-widget" uid="l8626bd4-eec7-4da3-86d8-677fb38e8278" data-uid="l8626bd4-eec7-4da3-86d8-677fb38e8278" role="option" aria-selected="false">
+                    <div class="contact-view k-widget" role="option" aria-selected="false">
                         <div class="header">
                             <span class="hidden-email" style="display:none">Zbyszek.Piestrzeniewicz@telerik.com</span>
                             <span class="image-wrapper">
@@ -245,7 +245,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="contact-view k-widget" uid="l8626bd4-eec7-4da3-86d8-677fb38e8278" data-uid="l8626bd4-eec7-4da3-86d8-677fb38e8278" role="option" aria-selected="false">
+                    <div class="contact-view k-widget" role="option" aria-selected="false">
                         <div class="header">
                             <span class="hidden-email" style="display:none">Zbyszek.Piestrzeniewicz@telerik.com</span>
                             <span class="image-wrapper">
@@ -262,7 +262,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="contact-view k-widget" uid="l8626bd4-eec7-4da3-86d8-677fb38e8278" data-uid="l8626bd4-eec7-4da3-86d8-677fb38e8278" role="option" aria-selected="false">
+                    <div class="contact-view k-widget" role="option" aria-selected="false">
                         <div class="header">
                             <span class="hidden-email" style="display:none">Zbyszek.Piestrzeniewicz@telerik.com</span>
                             <span class="image-wrapper">
@@ -356,11 +356,14 @@
             <div id="hijoCorreoNuevo" style="display: none;">
 
                 <div class="inner-section">
-                    <label class="form-label" for="to-textbox" id="to-textbox_label">Para:</label>
-                    <input type="text" class="k-input long-textbox to-textbox" name="to-textbox" value="" required>
-
-                    <label class="form-label" for="subject-textbox">Asunto:</label>
-                    <input type="text" class="k-input long-textbox subject-textbox" name="subject-textbox" value="">
+                    <label class="form-label" for="to-textbox" id="to-textbox_label">
+                        Para: &ensp; &ensp;&ensp;
+                        <input type="text" style="width:92%" name="to-textbox" value="" required>
+                    </label>
+                    <label class="form-label" for="subject-textbox">
+                        Asunto: &ensp;
+                        <input type="text" style="width:92%" name="subject-textbox" value="">
+                    </label>
 
                     <div class="attachements-line">
                         <label class="form-label" for="files">Archivos:</label>
@@ -374,7 +377,7 @@
                         </div>
                     </div>
 
-                    <table cellspacing="0" cellpadding="0" class="k-widget k-editor k-editor-widget" role="presentation" style="height: 500px;">
+                    <table cellspacing="0" cellpadding="0" class="k-widget k-editor k-editor-widget" role="presentation" style="height: 100%;">
                         <tbody>
                             <tr role="presentation">
                                 <td class="k-editor-toolbar-wrap" role="presentation">
@@ -508,5 +511,6 @@
 
 @section Scripts{
     <script src="~/js/paginaMails.js"></script>
+
 }
 

--- a/FRONTEND/FRONTEND/Views/Shared/_Layout.cshtml
+++ b/FRONTEND/FRONTEND/Views/Shared/_Layout.cshtml
@@ -19,13 +19,19 @@
 
     <nav id="superior" class="sb-topnav navbar navbar-expand navbar-dark bg-dark">
         <button class="btn btn-link btn-sm order-1 order-lg-0 " id="sidebarToggle"><i class="fas fa-bars"></i></button>
-
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 77.568 36" style="margin-left:3em;" width="77.568" height="36"><g color="#ff5576" fill="#ff5576" transform="translate(49.568 4) scale(0.538462)"><svg viewBox="0 0 52 52" x="0" y="0" width="52" height="52"><path fill="currentColor" fill-rule="evenodd" d="M 48.231 30.94 l -0.26 1.04 c 0 0.173 -0.087 0.173 -0.087 0.173 v -0.173 c 0.867 -7.973 -10.4 -12.566 -22.966 -12.566 c -2.514 0 -5.2 0.173 -7.714 0.606 c -3.986 0.607 -7.02 1.56 -9.186 2.6 c 0.26 2.774 2.773 3.12 4.333 3.12 h 0.52 c 2.253 -0.086 5.027 -0.52 6.413 -0.693 c 0.174 0 0.434 -0.087 0.52 -0.087 c 1.56 -0.173 3.207 -0.346 4.767 -0.346 c 7.02 0 14.04 1.905 17.767 6.153 c 3.639 4.16 2.426 9.013 -2.514 13.26 c -4.506 3.813 -10.314 4.592 -13.347 4.767 h -0.693 c -3.293 0 -6.153 -0.954 -6.673 -1.214 c -4.853 -1.906 -4.16 -5.113 -1.473 -6.846 c 2.166 -1.387 4.853 -1.994 7.366 -1.994 c 4.506 0 8.494 1.907 8.06 4.42 c -0.26 1.734 -2.34 2.687 -3.987 2.687 c -0.433 0 -0.867 -0.087 -1.213 -0.261 l -0.087 -0.086 c -0.086 -0.173 -0.173 -0.26 -0.606 -0.433 a 5.446 5.446 0 0 0 -1.647 -0.26 c -1.56 0 -3.206 0.607 -3.64 1.473 c -0.26 0.606 0.26 1.04 0.954 1.3 c 0.78 0.26 1.646 0.347 2.426 0.347 c 0.954 0 1.734 -0.087 2.167 -0.174 c 5.027 -0.867 9.446 -3.206 11.267 -5.286 c 1.473 -1.733 1.126 -4.16 -2.947 -6.067 c -3.467 -1.733 -7.887 -2.08 -11.18 -2.08 c -2.167 0 -3.813 0.174 -4.42 0.26 c -0.433 0.087 -3.207 0.434 -6.24 0.434 h -0.693 c -1.04 0 -1.994 -0.087 -3.034 -0.261 c -2.773 -0.346 -5.98 -2.686 -6.933 -6.067 a 12.367 12.367 0 0 1 -0.173 -0.952 v -0.52 c -0.087 -2.774 -0.26 -6.674 1.646 -9.36 c 3.814 -5.287 11.614 -7.627 19.587 -7.627 c 11.093 0 22.62 4.68 24.18 12.827 c 0.086 0 0.693 3.726 -0.26 7.886 M 23.791 3.207 a 22.726 22.726 0 0 1 20.02 8.493 c -5.113 -3.033 -11.613 -4.853 -18.633 -4.68 c -6.327 0.087 -12.134 1.734 -16.987 4.42 c 3.813 -4.506 9.273 -7.626 15.6 -8.233 m 28.08 20.28 c -0.52 -5.027 -2.427 -9.793 -5.633 -13.78 A 25.978 25.978 0 0 0 25.958 0 c -0.867 0 -1.647 0 -2.514 0.087 c -6.846 0.693 -13.086 3.987 -17.506 9.36 C 1.518 14.82 -0.562 21.58 0.13 28.427 C 1.344 41.947 12.698 52 25.958 52 c 0.866 0 1.646 0 2.513 -0.086 c 6.933 -0.695 13.173 -3.987 17.593 -9.361 a 26.535 26.535 0 0 0 5.807 -19.066" /></svg></g><path fill="#2da5cd" fill-rule="nonzero" transform="translate(0 9.6)" d="M 5.3 16.51 L 0 16.51 L 0 0 L 5.3 0 L 5.3 16.51 Z M 21.55 10.78 Q 21.55 13.87 19.79 15.34 Q 18.02 16.8 14.71 16.8 L 14.71 16.8 Q 11.4 16.8 9.64 15.34 Q 7.87 13.87 7.87 10.78 L 7.87 10.78 L 7.87 10.56 L 12.84 10.56 L 12.84 10.75 Q 12.84 11.88 13.26 12.36 Q 13.68 12.84 14.54 12.84 L 14.54 12.84 Q 15.41 12.84 15.83 12.36 Q 16.25 11.88 16.25 10.75 L 16.25 10.75 L 16.25 0 L 21.55 0 L 21.55 10.78 Z M 35.74 16.51 L 29.59 16.51 L 23.74 0 L 29.4 0 L 32.71 11.04 L 32.81 11.04 L 36.14 0 L 41.57 0 L 35.74 16.51 Z" /></svg>
 
         <!-- Navbar Search-->
         <form class="d-none d-md-inline-block form-inline ml-auto mr-0 mr-md-3 my-2 my-md-0">
         </form>
         <!-- Navbar-->
         <ul class="navbar-nav ml-auto ml-md-0">
+            <li class="nav-item">
+                <a asp-area="" asp-controller="Paginas" asp-action="MensajesTrabajador" class="nav-link icosSuperiores">
+                    <i class="fas fa-envelope"></i>
+                </a>
+            </li>
+
             <li class="nav-item">
                 <a href="#" class="nav-link icosSuperiores">
                     <i class="fas fa-expand"></i>
@@ -45,15 +51,14 @@
             </li>
             @if (SignInManager.IsSignedIn(User))
             {
-<li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle icosSuperiores" id="userDropdown" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fas fa-user fa-fw"></i></a>
-    <div class="dropdown-menu dropdown-menu-right" aria-labelledby="userDropdown">
-        <form class="form-inline" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Action("Index", "Home", new { area = "" })">
-            <button type="submit" class="nav-link btn btn-link text-dark">Cerrar sesión</button>
-        </form>
-    </div>
-</li>
-       }
+    <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle icosSuperiores" id="userDropdown" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fas fa-user fa-fw"></i></a>
+        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="userDropdown">
+            <form class="form-inline" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Action("Index", "Home", new { area = "" })">
+                <button type="submit" class="nav-link btn btn-link text-dark">Cerrar sesión</button>
+            </form>
+        </div>
+    </li>}
             <li>
                 <a href="#" class="nav-link icosSuperiores">
                     <i class="fa fa-th" aria-hidden="true"></i>
@@ -74,16 +79,6 @@
                                         <path d="M7 14s-1 0-1-1 1-4 5-4 5 3 5 4-1 1-1 1H7zm4-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6z" />
                                         <path fill-rule="evenodd" d="M5.216 14A2.238 2.238 0 0 1 5 13c0-1.355.68-2.75 1.936-3.72A6.325 6.325 0 0 0 5 9c-4 0-5 3-5 4s1 1 1 1h4.216z" />
                                         <path d="M4.5 8a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5z" />
-                                    </svg>
-                                </div>
-                            </a>
-                        </li>
-
-                        <li class="hov">
-                            <a class="nav-link" asp-area="" asp-controller="Paginas" asp-action="MensajesTrabajador">
-                                <div class="sb-nav-link-icon">
-                                    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi bi-envelope menu-icon" viewBox="0 0 16 16">
-                                        <path d="M0 4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V4zm2-1a1 1 0 0 0-1 1v.217l7 4.2 7-4.2V4a1 1 0 0 0-1-1H2zm13 2.383l-4.758 2.855L15 11.114v-5.73zm-.034 6.878L9.271 8.82 8 9.583 6.728 8.82l-5.694 3.44A1 1 0 0 0 2 13h12a1 1 0 0 0 .966-.739zM1 11.114l4.758-2.876L1 5.383v5.73z" />
                                     </svg>
                                 </div>
                             </a>

--- a/FRONTEND/FRONTEND/wwwroot/css/paginamails.css
+++ b/FRONTEND/FRONTEND/wwwroot/css/paginamails.css
@@ -1,6 +1,10 @@
 ﻿
 /* IAGO - VIKSEN - JOAN */
 
+#MailPage{
+    padding-top: 2em;
+    padding-right: 1em;
+}
 .padre{
     display:inline-flex;
 }
@@ -46,6 +50,15 @@ font-size: 20px;
     padding: 15px;
     margin-right: 50px;
 }
+.mailOptions {
+    color: rgb(142, 195, 238);
+}
+.toolbar{
+    margin-bottom:1em;
+}
+.searchbox{
+    margin-left: 1.5em;
+}
 
 /* FIN NOSOTROS */
 
@@ -75,8 +88,11 @@ font-size: 20px;
 
 /* List view - default */
 .list-view {
-  flex-direction: row; }
+  flex-direction: row; 
+  margin-left: 1em;
+}
   .list-view .list-view-inner {
+     
     flex: 1;
     overflow: auto;
     border-right: 1px solid #ebebeb;
@@ -300,15 +316,14 @@ body>div:last-child{ flex:none }
 }
 .main-content{
     display:flex;
-    flex:1;
-    min-height:100%;
-    overflow:auto
+    overflow:auto;
+    
 }
 .main-section{
     flex:1;
     position:relative;
     background:#fff;
-    box-shadow:0 0 4px 2px rgba(0,0,0,.06)
+    box-shadow:0 0 4px 2px rgba(0,0,0,.06);
 }
 .main-section .toolbar{ border-bottom:1px solid #ebebeb }
 .main-section .toolbar .left{ float:left }
@@ -326,7 +341,7 @@ body>div:last-child{ flex:none }
     padding:.71em
 }
 .main-section .toolbar .btn.iconOnly:before{
-    font:16px WebComponentsIcons;
+    font:15px WebComponentsIcons;
     display:inline-block
 }
 .main-section .toolbar .btn.iconOnly.selected{ color:#1e8edf }
@@ -352,7 +367,6 @@ body>div:last-child{ flex:none }
 .inner-section{
     display:flex;
     flex-direction:column;
-    height:calc(100% - 3em);
     overflow:auto
 }
 .searchbox{

--- a/FRONTEND/FRONTEND/wwwroot/css/styles.css
+++ b/FRONTEND/FRONTEND/wwwroot/css/styles.css
@@ -3,6 +3,9 @@
 /* VIKSEN----JOAN----IAGO----ADRIAN */
 
 /* pagina principal */
+body {
+    background-color: rgb(235,235,235);
+}
 #superior {
     background: linear-gradient(to right, rgb(23, 23, 104), rgb(75, 75, 255));
 }

--- a/FRONTEND/FRONTEND/wwwroot/js/site.js
+++ b/FRONTEND/FRONTEND/wwwroot/js/site.js
@@ -287,3 +287,18 @@ function getUnidadesOrganizativas(token) {
         }
     });
 }
+function Reloj() {
+    momentoActual = new Date()
+    hora = momentoActual.getHours()
+    minuto = momentoActual.getMinutes()
+    segundo = momentoActual.getSeconds()
+
+    horaImprimible = hora + " : " + minuto + " : " + segundo
+
+    document.form_reloj.reloj.value = horaImprimible
+
+    //La función se tendrá que llamar así misma para que sea dinámica, 
+    //de esta forma:
+
+    setTimeout(Reloj, 1000)
+}


### PR DESCRIPTION
Creacion del logo personal de grupo e implementacion.
Poner fondo gris muy claro a todas las paginas, manteniendo el de degradado de login, registro y etc.
Mover icono de Mail/Correo del nav izq al nav superior.
Arreglar cosillas de la pagina Mail, como paddings, margins, estructuración en general
Mover los botones del nav secundario (Trabajadores) a la derecha, como en las sugerencias del proyecto, también deshabilitarlos.